### PR TITLE
Map 추가 , 이동경로 , 시작점, 도착점 추가 , 기록 확인하는 화면 추가

### DIFF
--- a/GatheRunner.xcodeproj/project.pbxproj
+++ b/GatheRunner.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		DAE12F5D28D346FC00C328EA /* RunGuideItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE12F5C28D346FC00C328EA /* RunGuideItem.swift */; };
 		DAEA9315287AED7200349465 /* RunGuideExperienceTabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEA9314287AED7200349465 /* RunGuideExperienceTabItem.swift */; };
 		DAEA931A287D184900349465 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEA9319287D184900349465 /* BottomButtonView.swift */; };
+		DB1870D929212E8B00C51095 /* ResultMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1870D829212E8B00C51095 /* ResultMap.swift */; };
 		DB198DA8288F76FF002513A9 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB198DA7288F76FF002513A9 /* HeaderView.swift */; };
 		DBD4C52F28F3DFD1000E28D0 /* HistoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD4C52E28F3DFD1000E28D0 /* HistoryItem.swift */; };
 		DBD4C53128F3DFE0000E28D0 /* HistoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD4C53028F3DFE0000E28D0 /* HistoryList.swift */; };
@@ -135,6 +136,7 @@
 		DAEA930E28794F6F00349465 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DAEA9314287AED7200349465 /* RunGuideExperienceTabItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunGuideExperienceTabItem.swift; sourceTree = "<group>"; };
 		DAEA9319287D184900349465 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
+		DB1870D829212E8B00C51095 /* ResultMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultMap.swift; sourceTree = "<group>"; };
 		DB198DA7288F76FF002513A9 /* HeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		DBD4C52E28F3DFD1000E28D0 /* HistoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItem.swift; sourceTree = "<group>"; };
 		DBD4C53028F3DFE0000E28D0 /* HistoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryList.swift; sourceTree = "<group>"; };
@@ -352,6 +354,14 @@
 			path = TabItem;
 			sourceTree = "<group>";
 		};
+		DB1870D729212E2600C51095 /* Map */ = {
+			isa = PBXGroup;
+			children = (
+				DB1870D829212E8B00C51095 /* ResultMap.swift */,
+			);
+			path = Map;
+			sourceTree = "<group>";
+		};
 		DB198DAD288F7908002513A9 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -411,6 +421,7 @@
 		E35EFEB6286DFB2D003E23DE /* Presentaion */ = {
 			isa = PBXGroup;
 			children = (
+				DB1870D729212E2600C51095 /* Map */,
 				E35EFEBD286DFB2D003E23DE /* Commons */,
 				E35EFEC2286DFB2D003E23DE /* MainTab */,
 				E355960E28D45E8200AF0FBD /* Authentication */,
@@ -991,6 +1002,7 @@
 				E38C3AB52915471A00F0B104 /* OptionNameSpaces.swift in Sources */,
 				E3FE02FB28D49749008A9B91 /* String+isValid.swift in Sources */,
 				E39F0B5E28B75D0B0086957F /* ActivityHistoryView.swift in Sources */,
+				DB1870D929212E8B00C51095 /* ResultMap.swift in Sources */,
 				E355961328D4651900AF0FBD /* AuthenticationViewModel.swift in Sources */,
 				EA3D3F8D28D07C1000D78D28 /* PeriodView.swift in Sources */,
 				E39F0B5A28B75CF30086957F /* EmptyActivityView.swift in Sources */,

--- a/GatheRunner.xcodeproj/project.pbxproj
+++ b/GatheRunner.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		DAEA931A287D184900349465 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEA9319287D184900349465 /* BottomButtonView.swift */; };
 		DB1870D929212E8B00C51095 /* ResultMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1870D829212E8B00C51095 /* ResultMap.swift */; };
 		DB198DA8288F76FF002513A9 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB198DA7288F76FF002513A9 /* HeaderView.swift */; };
+		DB6C6E712929087100C18C37 /* MapWithPolyline.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6C6E702929087100C18C37 /* MapWithPolyline.swift */; };
 		DBD4C52F28F3DFD1000E28D0 /* HistoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD4C52E28F3DFD1000E28D0 /* HistoryItem.swift */; };
 		DBD4C53128F3DFE0000E28D0 /* HistoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD4C53028F3DFE0000E28D0 /* HistoryList.swift */; };
 		E305671128B75B6600DFA1C4 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E305671028B75B6600DFA1C4 /* LocationManager.swift */; };
@@ -138,6 +139,7 @@
 		DAEA9319287D184900349465 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
 		DB1870D829212E8B00C51095 /* ResultMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultMap.swift; sourceTree = "<group>"; };
 		DB198DA7288F76FF002513A9 /* HeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
+		DB6C6E702929087100C18C37 /* MapWithPolyline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapWithPolyline.swift; sourceTree = "<group>"; };
 		DBD4C52E28F3DFD1000E28D0 /* HistoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItem.swift; sourceTree = "<group>"; };
 		DBD4C53028F3DFE0000E28D0 /* HistoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryList.swift; sourceTree = "<group>"; };
 		E305671028B75B6600DFA1C4 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 			isa = PBXGroup;
 			children = (
 				DB1870D829212E8B00C51095 /* ResultMap.swift */,
+				DB6C6E702929087100C18C37 /* MapWithPolyline.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -1050,6 +1053,7 @@
 				E3607CD22923C1DF0018B2C2 /* LongPressTypeAlertModifier.swift in Sources */,
 				E3DA2F5828B76098001E9220 /* Constants.swift in Sources */,
 				DB198DA8288F76FF002513A9 /* HeaderView.swift in Sources */,
+				DB6C6E712929087100C18C37 /* MapWithPolyline.swift in Sources */,
 				DA7D5E7728F73A5F0066B2C6 /* RunGuideTabView.swift in Sources */,
 				E38C3AB62915472800F0B104 /* FireStoreRequest.swift in Sources */,
 				E3E748092892837700F40457 /* RunSplashScreen.swift in Sources */,

--- a/GatheRunner.xcodeproj/project.pbxproj
+++ b/GatheRunner.xcodeproj/project.pbxproj
@@ -1218,7 +1218,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GatheRunner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Running;
+				INFOPLIST_KEY_CFBundleDisplayName = GatheRunner;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치 권한 요청";
 				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "위치 권한 요청";
@@ -1257,7 +1257,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GatheRunner/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Running;
+				INFOPLIST_KEY_CFBundleDisplayName = GatheRunner;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.sports";
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치 권한 요청";
 				INFOPLIST_KEY_NSLocationAlwaysUsageDescription = "위치 권한 요청";

--- a/GatheRunner.xcodeproj/project.pbxproj
+++ b/GatheRunner.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		DAE12F5D28D346FC00C328EA /* RunGuideItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE12F5C28D346FC00C328EA /* RunGuideItem.swift */; };
 		DAEA9315287AED7200349465 /* RunGuideExperienceTabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEA9314287AED7200349465 /* RunGuideExperienceTabItem.swift */; };
 		DAEA931A287D184900349465 /* BottomButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEA9319287D184900349465 /* BottomButtonView.swift */; };
-		DB1870D929212E8B00C51095 /* ResultMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1870D829212E8B00C51095 /* ResultMap.swift */; };
+		DB1870D929212E8B00C51095 /* ResultMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB1870D829212E8B00C51095 /* ResultMapView.swift */; };
 		DB198DA8288F76FF002513A9 /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB198DA7288F76FF002513A9 /* HeaderView.swift */; };
 		DB6C6E712929087100C18C37 /* MapWithPolyline.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6C6E702929087100C18C37 /* MapWithPolyline.swift */; };
 		DBD4C52F28F3DFD1000E28D0 /* HistoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBD4C52E28F3DFD1000E28D0 /* HistoryItem.swift */; };
@@ -137,7 +137,7 @@
 		DAEA930E28794F6F00349465 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DAEA9314287AED7200349465 /* RunGuideExperienceTabItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunGuideExperienceTabItem.swift; sourceTree = "<group>"; };
 		DAEA9319287D184900349465 /* BottomButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomButtonView.swift; sourceTree = "<group>"; };
-		DB1870D829212E8B00C51095 /* ResultMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultMap.swift; sourceTree = "<group>"; };
+		DB1870D829212E8B00C51095 /* ResultMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultMapView.swift; sourceTree = "<group>"; };
 		DB198DA7288F76FF002513A9 /* HeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		DB6C6E702929087100C18C37 /* MapWithPolyline.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapWithPolyline.swift; sourceTree = "<group>"; };
 		DBD4C52E28F3DFD1000E28D0 /* HistoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryItem.swift; sourceTree = "<group>"; };
@@ -359,7 +359,7 @@
 		DB1870D729212E2600C51095 /* Map */ = {
 			isa = PBXGroup;
 			children = (
-				DB1870D829212E8B00C51095 /* ResultMap.swift */,
+				DB1870D829212E8B00C51095 /* ResultMapView.swift */,
 				DB6C6E702929087100C18C37 /* MapWithPolyline.swift */,
 			);
 			path = Map;
@@ -1005,7 +1005,7 @@
 				E38C3AB52915471A00F0B104 /* OptionNameSpaces.swift in Sources */,
 				E3FE02FB28D49749008A9B91 /* String+isValid.swift in Sources */,
 				E39F0B5E28B75D0B0086957F /* ActivityHistoryView.swift in Sources */,
-				DB1870D929212E8B00C51095 /* ResultMap.swift in Sources */,
+				DB1870D929212E8B00C51095 /* ResultMapView.swift in Sources */,
 				E355961328D4651900AF0FBD /* AuthenticationViewModel.swift in Sources */,
 				EA3D3F8D28D07C1000D78D28 /* PeriodView.swift in Sources */,
 				E39F0B5A28B75CF30086957F /* EmptyActivityView.swift in Sources */,

--- a/GatheRunner/Presentaion/Map/MapWithPolyline.swift
+++ b/GatheRunner/Presentaion/Map/MapWithPolyline.swift
@@ -1,0 +1,103 @@
+//
+//  MapWithPolyline.swift
+//  GatheRunner
+//
+//  Created by hanjaeseung on 2022/11/19.
+//
+
+import SwiftUI
+import MapKit
+
+struct MapWithPolyline: UIViewRepresentable {
+    
+    @Binding var region: MKCoordinateRegion
+    @Binding var lineCoordinates: [CLLocationCoordinate2D]
+    @Binding var startPosition: CLLocationCoordinate2D?
+    @Binding var endPosition: CLLocationCoordinate2D?
+    
+    func makeUIView(context: Context) -> MKMapView {
+        let mapView = MKMapView()
+        mapView.delegate = context.coordinator
+        mapView.region = region
+        mapView.userTrackingMode = .follow
+        let polyline = MKPolyline(coordinates: lineCoordinates, count: lineCoordinates.count)
+        mapView.addOverlay(polyline)
+        return mapView
+    }
+    
+    func updateUIView(_ view: MKMapView, context: Context) {
+        guard let startPosition = startPosition, let endPosition = endPosition else {
+            return
+        }
+        let startCircle = MKCircle(center: startPosition, radius: 7)
+        startCircle.circleType = .start
+        view.addOverlay(startCircle)
+        
+        let endcircle = MKCircle(center: endPosition, radius: 7)
+        endcircle.circleType = .end
+        view.addOverlay(endcircle)
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+    
+}
+
+class Coordinator: NSObject, MKMapViewDelegate {
+    var parent: MapWithPolyline
+    
+    init(_ parent: MapWithPolyline) {
+        self.parent = parent
+    }
+    
+    func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        zoomForAllOverlays(mapView: mapView)
+        if let routePolyline = overlay as? MKPolyline {
+            let renderer = MKPolylineRenderer(polyline: routePolyline)
+            renderer.strokeColor = UIColor.systemBlue
+            renderer.lineWidth = 5
+            return renderer
+        } else if overlay is MKCircle {
+            let circleRenderer = MKCircleRenderer(overlay: overlay)
+            let strokColor: UIColor = .white
+            let color: UIColor = (circleRenderer.circle.circleType == .start) ? .green : .red
+            circleRenderer.strokeColor = strokColor
+            circleRenderer.fillColor = color
+            circleRenderer.lineWidth = 2.0
+            return circleRenderer
+        }
+        return MKOverlayRenderer()
+    }
+    
+    func zoomForAllOverlays(mapView: MKMapView) {
+        let insets = UIEdgeInsets(top: 50, left: 50, bottom: 50, right: 50)
+        guard let initial = mapView.overlays.first?.boundingMapRect else { return }
+
+        let mapRect = mapView.overlays
+            .dropFirst()
+            .reduce(initial) { $0.union($1.boundingMapRect) }
+
+        mapView.setVisibleMapRect(mapRect, edgePadding: insets, animated: true)
+    }
+}
+
+extension MKCircle {
+    
+    enum type {
+        case start
+        case end
+    }
+    
+    private static var savedCircleType: type = .start
+    
+    var circleType: type {
+        get{
+            return MKCircle.savedCircleType
+        }
+        set(newValue) {
+            MKCircle.savedCircleType = newValue
+        }
+    }
+    
+}

--- a/GatheRunner/Presentaion/Map/MapWithPolyline.swift
+++ b/GatheRunner/Presentaion/Map/MapWithPolyline.swift
@@ -54,20 +54,28 @@ class Coordinator: NSObject, MKMapViewDelegate {
     func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
         zoomForAllOverlays(mapView: mapView)
         if let routePolyline = overlay as? MKPolyline {
-            let renderer = MKPolylineRenderer(polyline: routePolyline)
-            renderer.strokeColor = UIColor.systemBlue
-            renderer.lineWidth = 5
-            return renderer
+            return drawPolyLine(polyLine: routePolyline)
         } else if overlay is MKCircle {
-            let circleRenderer = MKCircleRenderer(overlay: overlay)
-            let strokColor: UIColor = .white
-            let color: UIColor = (circleRenderer.circle.circleType == .start) ? .green : .red
-            circleRenderer.strokeColor = strokColor
-            circleRenderer.fillColor = color
-            circleRenderer.lineWidth = 2.0
-            return circleRenderer
+            return drawCircle(overlay: overlay)
         }
         return MKOverlayRenderer()
+    }
+    
+    func drawCircle(overlay: MKOverlay) -> MKCircleRenderer{
+        let circleRenderer = MKCircleRenderer(overlay: overlay)
+        let strokColor: UIColor = .white
+        let color: UIColor = (circleRenderer.circle.circleType == .start) ? .green : .red
+        circleRenderer.strokeColor = strokColor
+        circleRenderer.fillColor = color
+        circleRenderer.lineWidth = 2.0
+        return circleRenderer
+    }
+    
+    func drawPolyLine(polyLine: MKPolyline) -> MKPolylineRenderer {
+        let renderer = MKPolylineRenderer(polyline: polyLine)
+        renderer.strokeColor = UIColor.systemBlue
+        renderer.lineWidth = 5
+        return renderer
     }
     
     func zoomForAllOverlays(mapView: MKMapView) {

--- a/GatheRunner/Presentaion/Map/ResultMap.swift
+++ b/GatheRunner/Presentaion/Map/ResultMap.swift
@@ -1,0 +1,27 @@
+//
+//  ResultMap.swift
+//  GatheRunner
+//
+//  Created by hanJaeseung on 2022/11/13.
+//
+
+import SwiftUI
+import MapKit
+
+struct ResultMap: View {
+    @ObservedObject var manager: LocationManager
+    
+    var body: some View {
+        Map(coordinateRegion: $manager.resultMapRegion, showsUserLocation: false)
+            .disabled(false)
+            .clipShape(RoundedRectangle(cornerRadius: 15))
+            .padding(.horizontal, 30)
+            
+    }
+}
+
+struct ResultMap_Previews: PreviewProvider {
+    static var previews: some View {
+        ResultMap(manager: LocationManager())
+    }
+}

--- a/GatheRunner/Presentaion/Map/ResultMap.swift
+++ b/GatheRunner/Presentaion/Map/ResultMap.swift
@@ -12,8 +12,12 @@ struct ResultMap: View {
     @ObservedObject var manager: LocationManager
     
     var body: some View {
-        Map(coordinateRegion: $manager.resultMapRegion, showsUserLocation: false)
-            .disabled(false)
+        MapWithPolyline(
+            region: $manager.resultMapRegion,
+            lineCoordinates: $manager.polylineData,
+            startPosition: $manager.startPosition,
+            endPosition: $manager.endPosition
+        )
             .clipShape(RoundedRectangle(cornerRadius: 15))
             .padding(.horizontal, 30)
             

--- a/GatheRunner/Presentaion/Map/ResultMapView.swift
+++ b/GatheRunner/Presentaion/Map/ResultMapView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import MapKit
 
-struct ResultMap: View {
+struct ResultMapView: View {
     @ObservedObject var manager: LocationManager
     
     var body: some View {
@@ -26,6 +26,6 @@ struct ResultMap: View {
 
 struct ResultMap_Previews: PreviewProvider {
     static var previews: some View {
-        ResultMap(manager: LocationManager())
+        ResultMapView(manager: LocationManager())
     }
 }

--- a/GatheRunner/Presentaion/Running/Views/RunningView/RunningRecordView.swift
+++ b/GatheRunner/Presentaion/Running/Views/RunningView/RunningRecordView.swift
@@ -15,9 +15,13 @@ struct RunningRecordView: View {
     
     var body: some View {
         VStack(spacing: Size.mainVerticalSpacing) {
+            ResultMap(manager: manager)
+                .isEmpty(logicalOperator: .and, [!isRunning, !isInitialState])
             timerView
             realTimeRecordView
             stopWatchButtonLayer
+            Spacer()
+                .isEmpty(logicalOperator: .and, [!isRunning, !isInitialState])
         }
     }
     
@@ -35,7 +39,7 @@ struct RunningRecordView: View {
     private enum Content {
         enum Label {
             static let exerciseTime = "운동 시간"
-            static let kilometer = "알림"
+            static let kilometer = "거리"
             static let pace = "페이스"
             static let recordFormat = "%.2f"
             static let empty = ""
@@ -49,6 +53,7 @@ struct RunningRecordView: View {
     }
     
     @State private var isRunning = false
+    @State private var isInitialState = true
     @EnvironmentObject private var manager: LocationManager
 }
 
@@ -74,7 +79,7 @@ extension RunningRecordView {
     
     private var stopWatchButtonLayer: some View {
         HStack(spacing: Size.stopWatchHorizontalSpacing) {
-            stopButton.isEmpty(logicalOperator: .none, [isRunning == true])
+            stopButton.isEmpty(logicalOperator: .none, [isRunning])
             resumeButton
         }
     }
@@ -83,13 +88,20 @@ extension RunningRecordView {
         Button(action: { }) {
             Image(Content.Image.stop)
                 .asIconStyle(withMaxWidth: Size.stopWatchImage, withMaxHeight: Size.stopWatchImage)
-                .addLongPressTypeAlert(withAction: manager.didUnSetStartLocation)
+                .addLongPressTypeAlert(withAction: {
+                    isRunning = false
+                    manager.didStopRecording()
+                    
+                })
         }
     }
     
     private var resumeButton: some View {
         Toggle(Content.Label.empty, isOn: $isRunning)
             .onChange(of: isRunning) {
+                if isInitialState {
+                    isInitialState = false
+                }
                 $0 ? manager.didSetStartLocation() : manager.didUnSetStartLocation()
             }
             .toggleStyle(IconStyle(onImage: Content.Image.play, offImage: Content.Image.pause, size: Size.stopWatchImage))

--- a/GatheRunner/Presentaion/Running/Views/RunningView/RunningRecordView.swift
+++ b/GatheRunner/Presentaion/Running/Views/RunningView/RunningRecordView.swift
@@ -15,7 +15,7 @@ struct RunningRecordView: View {
     
     var body: some View {
         VStack(spacing: Size.mainVerticalSpacing) {
-            ResultMap(manager: manager)
+            ResultMapView(manager: manager)
                 .isEmpty(logicalOperator: .and, [!isRunning, !isInitialState])
             timerView
             realTimeRecordView

--- a/GatheRunner/Utils/LocationManager.swift
+++ b/GatheRunner/Utils/LocationManager.swift
@@ -7,6 +7,12 @@ import SwiftUI
 // MARK: - 예외처리 구현 필요
 
 class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
+    
+    enum RecordState {
+        case start
+        case pause
+        case stopped
+    }
 
     // MARK: Lifecycle
 
@@ -22,12 +28,15 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     // MARK: Internal
 
     @Published var region = MKCoordinateRegion()
-    @Published var startLocation: CLLocation?
     @Published var resultMapRegion = MKCoordinateRegion()
     @Published var distance = CLLocationDistance()
     @Published var currentPace = Double()
     @Published var minutes = "00"
     @Published var seconds = "00"
+    @Published var polylineData = [CLLocationCoordinate2D]()
+    @Published var endPosition: CLLocationCoordinate2D?
+    @Published var startPosition: CLLocationCoordinate2D?
+    
     var oldLocation = CLLocationCoordinate2D()
 
     func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
@@ -35,13 +44,16 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
             let center = CLLocationCoordinate2D(latitude: $0.coordinate.latitude, longitude: $0.coordinate.longitude)
             let span = MKCoordinateSpan(latitudeDelta: 0.004, longitudeDelta: 0.004)
             self.oldLocation = region.center
+            polylineData.append(center)
             region = MKCoordinateRegion(center: center, span: span)
+            
         }
     }
 
     func didSetStartLocation() {
-        startLocation = CLLocation(latitude: region.center.latitude, longitude: region.center.longitude)
         resultMapRegion = region
+        
+        recordState = .start
         timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
             guard let self = self else { return }
             self.progressTime += 1
@@ -51,23 +63,24 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     }
 
     func didUnSetStartLocation() {
-        startLocation = nil
+        if recordState == .start {
+            recordState = .pause
+        }
+        
         timer?.invalidate()
+        resultMapRegion.center = region.center
     }
     
     func didStopRecording() {
-        startLocation = nil
+        recordState = .stopped
+        self.endPosition = self.region.center
         timer?.invalidate()
-        self.progressTime = 0
-        self.minutes = "00"
-        self.seconds = "00"
-        self.currentPace = 0
-        self.distance = 0
+        
     }
 
     func setupSubscriptions() {
         $region.sink { [weak self] in
-            guard let self = self, let startLocation = self.startLocation else { return }
+            guard let self = self, self.recordState == .start else { return }
             let to = CLLocation(latitude: $0.center.latitude, longitude: $0.center.longitude)
             self.currentPace = (Double(self.progressTime) / 60.0) / self.distance
             self.distance += CLLocation(latitude: self.oldLocation.latitude, longitude: self.oldLocation.longitude).distance(from: to) / 1000.0
@@ -80,6 +93,21 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     private let manager = CLLocationManager()
     private var disposables = Set<AnyCancellable>()
     private var timer: Timer?
+    private var recordState: RecordState = .stopped {
+        didSet {
+            if oldValue == .stopped && recordState == .start {
+                self.startPosition = nil
+                self.endPosition = nil
+                self.polylineData.removeAll()
+                self.progressTime = 0
+                self.minutes = "00"
+                self.seconds = "00"
+                self.currentPace = 0
+                self.distance = 0
+                self.startPosition = region.center
+                
+            }
+        }
+    }
     private var progressTime = 0
 }
-

--- a/GatheRunner/Utils/LocationManager.swift
+++ b/GatheRunner/Utils/LocationManager.swift
@@ -66,7 +66,6 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
         if recordState == .start {
             recordState = .pause
         }
-        
         timer?.invalidate()
         resultMapRegion.center = region.center
     }
@@ -87,6 +86,17 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
         }
         .store(in: &disposables)
     }
+    
+    func publishedDataInit() {
+        self.startPosition = nil
+        self.endPosition = nil
+        self.polylineData.removeAll()
+        self.progressTime = 0
+        self.minutes = "00"
+        self.seconds = "00"
+        self.currentPace = 0
+        self.distance = 0
+    }
 
     // MARK: Private
 
@@ -96,14 +106,7 @@ class LocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     private var recordState: RecordState = .stopped {
         didSet {
             if oldValue == .stopped && recordState == .start {
-                self.startPosition = nil
-                self.endPosition = nil
-                self.polylineData.removeAll()
-                self.progressTime = 0
-                self.minutes = "00"
-                self.seconds = "00"
-                self.currentPace = 0
-                self.distance = 0
+                self.publishedDataInit()
                 self.startPosition = region.center
                 
             }


### PR DESCRIPTION
개발 내용
-------------------------
- Map이 추가되었습니다
- 맵에 이동경로는 MKMapPolyline으로 구현, 시작점과 도착점 circle로 구현
- polyline과 circle을 그리기위해 어쩔수 없이 MKMapView를 표현할 UIViewRepresentable 을 사용
- LocationManager의 거리, 페이스 계산
- 달리기 도중 현재 앱의 상태가 기록중, 일시정지, 기록 대기중인지 구분하는 enum 값 설정 -> enum을 확인하여 데이터 초기화

TODO
--------------------------
- LocationManager를 VM처럼 사용하고 있어서 LocationManager는 위치만 받아오는 용도로 분리
- RecordingView의 VM 따로 생성 필요


https://user-images.githubusercontent.com/31721888/202859600-39ff0edc-475e-4d14-9dcb-bc3406082aa3.mp4

