### PR TITLE
[Add] Status+Lodable & [Refactor]  Authentication

### DIFF
--- a/GatheRunner.xcodeproj/project.pbxproj
+++ b/GatheRunner.xcodeproj/project.pbxproj
@@ -73,6 +73,10 @@
 		E399CA7F2933963100ACFCFA /* FirebaseUserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3435A022922820D00B65D48 /* FirebaseUserRepository.swift */; };
 		E399CA8229339C9F00ACFCFA /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399CA8129339C9F00ACFCFA /* UserManager.swift */; };
 		E399CA8529339E2000ACFCFA /* AuthSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399CA8429339E2000ACFCFA /* AuthSettingView.swift */; };
+		E399CAC82935F83B00ACFCFA /* LoadableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399CAC72935F83B00ACFCFA /* LoadableView.swift */; };
+		E399CACC2936199C00ACFCFA /* FetchStatusType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399CACB2936199C00ACFCFA /* FetchStatusType.swift */; };
+		E399CACE29362D5600ACFCFA /* ActivityIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399CACD29362D5600ACFCFA /* ActivityIndicatorView.swift */; };
+		E399CAD029362DBE00ACFCFA /* ErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E399CACF29362DBE00ACFCFA /* ErrorView.swift */; };
 		E39F0B5A28B75CF30086957F /* EmptyActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4D0FE628B634C00005A5F3 /* EmptyActivityView.swift */; };
 		E39F0B5D28B75D0B0086957F /* GraphViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5E279128B604B7004C0798 /* GraphViewModel.swift */; };
 		E39F0B5E28B75D0B0086957F /* ActivityHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4D0FE828B63B210005A5F3 /* ActivityHistoryView.swift */; };
@@ -199,6 +203,10 @@
 		E399CA7D293395C800ACFCFA /* AppEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppEnvironment.swift; sourceTree = "<group>"; };
 		E399CA8129339C9F00ACFCFA /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		E399CA8429339E2000ACFCFA /* AuthSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSettingView.swift; sourceTree = "<group>"; };
+		E399CAC72935F83B00ACFCFA /* LoadableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadableView.swift; sourceTree = "<group>"; };
+		E399CACB2936199C00ACFCFA /* FetchStatusType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchStatusType.swift; sourceTree = "<group>"; };
+		E399CACD29362D5600ACFCFA /* ActivityIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorView.swift; sourceTree = "<group>"; };
+		E399CACF29362DBE00ACFCFA /* ErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorView.swift; sourceTree = "<group>"; };
 		E3D349D3286C20D200618AC3 /* GatheRunner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GatheRunner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3D349D6286C20D200618AC3 /* GatheRunnerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GatheRunnerApp.swift; sourceTree = "<group>"; };
 		E3D349D8286C20D200618AC3 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
@@ -377,6 +385,7 @@
 				E3DA2F5728B7607F001E9220 /* TouchLocationView.swift */,
 				E305671028B75B6600DFA1C4 /* LocationManager.swift */,
 				DB051390292BDE7B00BE218B /* Date+Extension.swift */,
+				E399CACB2936199C00ACFCFA /* FetchStatusType.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -501,6 +510,8 @@
 				E35EFEBE286DFB2D003E23DE /* TabItem.swift */,
 				E3F5989F292A0E2200023097 /* MainTabComponents.swift */,
 				E335FAF828B7610300835F72 /* SelectedTab.swift */,
+				E399CACD29362D5600ACFCFA /* ActivityIndicatorView.swift */,
+				E399CACF29362DBE00ACFCFA /* ErrorView.swift */,
 			);
 			path = Commons;
 			sourceTree = "<group>";
@@ -533,6 +544,7 @@
 			children = (
 				E3708FF0289BBEE6004FF0C1 /* EmptyModifier.swift */,
 				E3607CD12923C1DF0018B2C2 /* LongPressTypeAlertModifier.swift */,
+				E399CAC72935F83B00ACFCFA /* LoadableView.swift */,
 			);
 			path = Modifier;
 			sourceTree = "<group>";
@@ -1059,6 +1071,8 @@
 				E355961328D4651900AF0FBD /* AuthenticationViewModel.swift in Sources */,
 				EA3D3F8D28D07C1000D78D28 /* PeriodView.swift in Sources */,
 				E39F0B5A28B75CF30086957F /* EmptyActivityView.swift in Sources */,
+				E399CACE29362D5600ACFCFA /* ActivityIndicatorView.swift in Sources */,
+				E399CACC2936199C00ACFCFA /* FetchStatusType.swift in Sources */,
 				E3DA2F5B28B76098001E9220 /* GatherNaviBar.swift in Sources */,
 				EA3D3F8F28D07C1000D78D28 /* Graph.swift in Sources */,
 				E305671328B75BA200DFA1C4 /* Int+Extensions.swift in Sources */,
@@ -1106,11 +1120,13 @@
 				E355961028D45ECB00AF0FBD /* AuthenticationView.swift in Sources */,
 				E38C3AB2291546FB00F0B104 /* Firestore+Combine.swift in Sources */,
 				E3607CD22923C1DF0018B2C2 /* LongPressTypeAlertModifier.swift in Sources */,
+				E399CAC82935F83B00ACFCFA /* LoadableView.swift in Sources */,
 				E3DA2F5828B76098001E9220 /* Constants.swift in Sources */,
 				DB198DA8288F76FF002513A9 /* HeaderView.swift in Sources */,
 				DA7D5E7728F73A5F0066B2C6 /* RunGuideTabView.swift in Sources */,
 				E31D52602927A6040067DF48 /* AuthRequest.swift in Sources */,
 				E38C3AB62915472800F0B104 /* FireStoreRequest.swift in Sources */,
+				E399CAD029362DBE00ACFCFA /* ErrorView.swift in Sources */,
 				E3E748092892837700F40457 /* RunSplashScreen.swift in Sources */,
 				DA7D5E7B28F740D90066B2C6 /* MapView.swift in Sources */,
 				E3D349D7286C20D200618AC3 /* GatheRunnerApp.swift in Sources */,

--- a/GatheRunner/Helper/UI/Modifier/LoadableView.swift
+++ b/GatheRunner/Helper/UI/Modifier/LoadableView.swift
@@ -1,0 +1,39 @@
+//
+//  LoadableView.swift
+//  GatheRunner
+//
+//  Created by 김동현 on 2022/11/29.
+//
+
+import SwiftUI
+
+typealias ErrorOption = (errorMessage: String, retryAction: () -> Void)
+
+struct LoadableView: ViewModifier {
+    
+    @Binding var fetchStatus: FetchStatus
+    var errorOption: ErrorOption?
+    
+    func body(content: Content) -> some View {
+        Group {
+            switch fetchStatus {
+            case .fetching: ActivityIndicatorView()
+            case .failure:
+                if let errorOption = errorOption {
+                    ErrorView(errorMessage: errorOption.errorMessage, retryAction: errorOption.retryAction)
+                } else {
+                    content
+                }
+                
+            default: content
+            }
+        }
+    }
+}
+
+extension View {
+    func didSetLoadable(by fetchStatus: Binding<FetchStatus>,
+                        withError errorOption: ErrorOption? = nil) -> some View {
+        modifier(LoadableView(fetchStatus: fetchStatus, errorOption: errorOption))
+    }
+}

--- a/GatheRunner/Helper/UI/Modifier/LoadableView.swift
+++ b/GatheRunner/Helper/UI/Modifier/LoadableView.swift
@@ -10,21 +10,15 @@ import SwiftUI
 typealias ErrorOption = (errorMessage: String, retryAction: () -> Void)
 
 struct LoadableView: ViewModifier {
-    
     @Binding var fetchStatus: FetchStatus
+    
     var errorOption: ErrorOption?
     
     func body(content: Content) -> some View {
         Group {
-            switch fetchStatus {
-            case .fetching: ActivityIndicatorView()
-            case .failure:
-                if let errorOption = errorOption {
-                    ErrorView(errorMessage: errorOption.errorMessage, retryAction: errorOption.retryAction)
-                } else {
-                    content
-                }
-                
+            switch (fetchStatus, errorOption) {
+            case (.fetching, _): ActivityIndicatorView()
+            case (.failure, .some(let option)): ErrorView(errorMessage: option.errorMessage, retryAction: option.retryAction)
             default: content
             }
         }

--- a/GatheRunner/Presentaion/Authentication/View/AuthSettingView.swift
+++ b/GatheRunner/Presentaion/Authentication/View/AuthSettingView.swift
@@ -28,7 +28,7 @@ struct AuthSettingView: View {
     var body: some View {
         buttonLayer
             .didSetLoadable(by: $viewModel.fetchStatus)
-            .onAppear { bindFetch() }
+            .onAppear { bindFetchStatus() }
             .alert(isPresented: $isShownAlert) {
                 Alert(
                     title: Text(Label.alertTitle),
@@ -51,7 +51,7 @@ struct AuthSettingView: View {
         }
     }
     
-    private func bindFetch() {
+    private func bindFetchStatus() {
         viewModel.$fetchStatus
             .sink {
                 switch $0 {

--- a/GatheRunner/Presentaion/Authentication/View/AuthSettingView.swift
+++ b/GatheRunner/Presentaion/Authentication/View/AuthSettingView.swift
@@ -11,30 +11,55 @@ struct AuthSettingView: View {
     private enum Size {
         static let spacing: CGFloat = 20
     }
-
+    
     private enum Label {
         static let userInfoSetting = "회원정보 설정"
         static let signOut = "로그아웃"
         static let deleteUser = "회원탈퇴"
         static let cancle = "취소"
+        static let confirm = "확인"
+        static let alertTitle = "알림"
     }
     
     @Binding var isShownSheet: Bool
     @StateObject var viewModel: AuthenticationViewModel
+    @State private var isShownAlert = false
     
     var body: some View {
+        buttonLayer
+            .didSetLoadable(by: $viewModel.fetchStatus)
+            .onAppear { bindFetch() }
+            .alert(isPresented: $isShownAlert) {
+                Alert(
+                    title: Text(Label.alertTitle),
+                    message: Text(viewModel.errorMessage),
+                    dismissButton: .default(Text(Label.confirm)))
+            }
+    }
+    
+    private var buttonLayer: some View {
         VStack(spacing: Size.spacing) {
             Button(Label.signOut) {
                 viewModel.signOut()
-                isShownSheet.toggle()
             }
             Button(Label.deleteUser) {
                 viewModel.deleteUser()
-                isShownSheet.toggle()
             }
             Button(Label.cancle) {
                 isShownSheet.toggle()
             }
         }
+    }
+    
+    private func bindFetch() {
+        viewModel.$fetchStatus
+            .sink {
+                switch $0 {
+                case .success: isShownSheet.toggle()
+                case .failure: isShownAlert.toggle()
+                default: return
+                }
+            }
+            .store(in: &viewModel.cancelBag)
     }
 }

--- a/GatheRunner/Presentaion/Authentication/ViewModel/AuthenticationViewModel.swift
+++ b/GatheRunner/Presentaion/Authentication/ViewModel/AuthenticationViewModel.swift
@@ -30,7 +30,7 @@ final class AuthenticationViewModel: ObservableObject {
         self.userRepository = userRepository
         self.userManager = userManager
         bindValidation()
-        bindFetch()
+        bindFetchStatus()
     }
 }
 
@@ -137,7 +137,7 @@ extension AuthenticationViewModel {
             .store(in: &cancelBag)
     }
     
-    private func bindFetch() {
+    private func bindFetchStatus() {
         fetchStatusSubject.assign(to: \.fetchStatus, on: self)
             .store(in: &cancelBag)
     }

--- a/GatheRunner/Presentaion/Authentication/ViewModel/AuthenticationViewModel.swift
+++ b/GatheRunner/Presentaion/Authentication/ViewModel/AuthenticationViewModel.swift
@@ -145,7 +145,7 @@ extension AuthenticationViewModel {
     private func bindError(_ error: Error) {
         fetchStatusSubject.send(.failure)
         
-        // MARK: Temp errorMessage
+        // MARK: Temp errorMessage Handling
 
         errorMessage = error.localizedDescription
     }

--- a/GatheRunner/Presentaion/Authentication/ViewModel/AuthenticationViewModel.swift
+++ b/GatheRunner/Presentaion/Authentication/ViewModel/AuthenticationViewModel.swift
@@ -15,7 +15,6 @@ final class AuthenticationViewModel: ObservableObject {
     @Published var inputPassword = ""
     @Published var isEmailValid = false
     @Published var isPasswordValid = false
-    @Published var isInputsValid = false
     @Published var fetchStatus: FetchStatus = .none
         
     var cancelBag = Set<AnyCancellable>()
@@ -35,11 +34,10 @@ final class AuthenticationViewModel: ObservableObject {
     }
 }
 
-// MARK: Internal Methods
+// MARK: Auth Methods
 
 extension AuthenticationViewModel {
     func signIn() {
-        guard validatedInputs() else { return }
         fetchStatusSubject.send(.fetching)
 
         userRepository.signIn(AuthRequest(email: inputEmail, password: inputPassword))
@@ -59,7 +57,6 @@ extension AuthenticationViewModel {
     }
 
     func signUp() {
-        guard validatedInputs() else { return }
         fetchStatusSubject.send(.fetching)
 
         userRepository.signUp(AuthRequest(email: inputEmail, password: inputPassword))
@@ -121,7 +118,7 @@ extension AuthenticationViewModel {
     }
 }
 
-// MARK: Private Methods
+// MARK: Private Bind
 
 extension AuthenticationViewModel {
     private func bindValidation() {
@@ -151,14 +148,5 @@ extension AuthenticationViewModel {
         // MARK: Temp errorMessage
 
         errorMessage = error.localizedDescription
-    }
-
-    private func validatedInputs() -> Bool {
-        guard isEmailValid, isPasswordValid else {
-            isInputsValid = false
-            return isInputsValid
-        }
-        isInputsValid = true
-        return isInputsValid
     }
 }

--- a/GatheRunner/Presentaion/Authentication/ViewModel/AuthenticationViewModel.swift
+++ b/GatheRunner/Presentaion/Authentication/ViewModel/AuthenticationViewModel.swift
@@ -16,10 +16,12 @@ final class AuthenticationViewModel: ObservableObject {
     @Published var isEmailValid = false
     @Published var isPasswordValid = false
     @Published var isInputsValid = false
-    @Published var isAuthValid = false
-
+    @Published var fetchStatus: FetchStatus = .none
+        
     var cancelBag = Set<AnyCancellable>()
-
+    var errorMessage = ""
+    
+    private let fetchStatusSubject = CurrentValueSubject<FetchStatus, Never>(.none)
     private let userRepository: UserRepository
     private let userManager: UserManager
 
@@ -28,8 +30,8 @@ final class AuthenticationViewModel: ObservableObject {
     init(userRepository: UserRepository, userManager: UserManager) {
         self.userRepository = userRepository
         self.userManager = userManager
-
         bindValidation()
+        bindFetch()
     }
 }
 
@@ -38,62 +40,82 @@ final class AuthenticationViewModel: ObservableObject {
 extension AuthenticationViewModel {
     func signIn() {
         guard validatedInputs() else { return }
+        fetchStatusSubject.send(.fetching)
 
         userRepository.signIn(AuthRequest(email: inputEmail, password: inputPassword))
             .sink { [weak self] completion in
                 switch completion {
-                case .failure(_): self?.isAuthValid = false
-
-                default: print("completion \(completion)")
+                case .failure(let error): self?.bindError(error)
+                default: return
                 }
 
             } receiveValue: { [weak self] user in
-                self?.userManager.setInfo(with: user)
+                guard let self = self else { return }
+                
+                self.userManager.setInfo(with: user)
+                self.fetchStatusSubject.send(.success)
             }
             .store(in: &cancelBag)
     }
 
     func signUp() {
         guard validatedInputs() else { return }
+        fetchStatusSubject.send(.fetching)
 
         userRepository.signUp(AuthRequest(email: inputEmail, password: inputPassword))
             .sink { [weak self] completion in
                 switch completion {
-                case .failure(_): self?.isAuthValid = false
+                case .failure(let error): self?.bindError(error)
+                default: return
 
-                default: print("completion \(completion)")
                 }
 
             } receiveValue: { [weak self] user in
-                self?.userManager.setInfo(with: user)
+                guard let self = self else { return }
+
+                self.userManager.setInfo(with: user)
+                self.fetchStatusSubject.send(.success)
+
             }
             .store(in: &cancelBag)
     }
 
     func signOut() {
+        fetchStatusSubject.send(.fetching)
+
         userRepository.signOut()
-            .sink { completion in
+            .sink { [weak self] completion in
                 switch completion {
-                case .failure(let error): print("error \(error)")
-                default: print("completion \(completion)")
+                case .failure(let error): self?.bindError(error)
+                default: return
                 }
 
-            } receiveValue: { [weak self] _ in
-                self?.userManager.isSignIn = false
+            } receiveValue: { [weak self] result in
+                guard let self = self, result else { return }
+                
+                self.userManager.isSignIn = false
+                self.fetchStatusSubject.send(.success)
             }
             .store(in: &cancelBag)
     }
 
     func deleteUser() {
+        fetchStatusSubject.send(.fetching)
+        
         userRepository.deleteUser()
-            .sink { completion in
+            .sink { [weak self] completion in
                 switch completion {
-                case .failure(let error): print("error \(error)")
-                default: print("completion \(completion)")
+                case .failure(let error):
+                    self?.bindError(error)
+
+                default: return
                 }
 
-            } receiveValue: { [weak self] _ in
-                self?.userManager.isSignIn = false
+            } receiveValue: { [weak self] result in
+                guard let self = self, result else { return }
+
+                self.userManager.isSignIn = false
+                self.fetchStatusSubject.send(.success)
             }
             .store(in: &cancelBag)
     }
@@ -116,6 +138,19 @@ extension AuthenticationViewModel {
                 self?.isPasswordValid = $0.isPasswordValid
             }
             .store(in: &cancelBag)
+    }
+    
+    private func bindFetch() {
+        fetchStatusSubject.assign(to: \.fetchStatus, on: self)
+            .store(in: &cancelBag)
+    }
+    
+    private func bindError(_ error: Error) {
+        fetchStatusSubject.send(.failure)
+        
+        // MARK: Temp errorMessage
+
+        errorMessage = error.localizedDescription
     }
 
     private func validatedInputs() -> Bool {

--- a/GatheRunner/Presentaion/Commons/ActivityIndicatorView.swift
+++ b/GatheRunner/Presentaion/Commons/ActivityIndicatorView.swift
@@ -1,0 +1,19 @@
+//
+//  ActivityIndicatorView.swift
+//  GatheRunner
+//
+//  Created by 김동현 on 2022/11/29.
+//
+
+import SwiftUI
+
+struct ActivityIndicatorView: UIViewRepresentable {
+
+    func makeUIView(context: UIViewRepresentableContext<ActivityIndicatorView>) -> UIActivityIndicatorView {
+        return UIActivityIndicatorView(style: .large)
+    }
+
+    func updateUIView(_ uiView: UIActivityIndicatorView, context: UIViewRepresentableContext<ActivityIndicatorView>) {
+        uiView.startAnimating()
+    }
+}

--- a/GatheRunner/Presentaion/Commons/ActivityIndicatorView.swift
+++ b/GatheRunner/Presentaion/Commons/ActivityIndicatorView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct ActivityIndicatorView: UIViewRepresentable {
-
     func makeUIView(context: UIViewRepresentableContext<ActivityIndicatorView>) -> UIActivityIndicatorView {
         return UIActivityIndicatorView(style: .large)
     }

--- a/GatheRunner/Presentaion/Commons/ErrorView.swift
+++ b/GatheRunner/Presentaion/Commons/ErrorView.swift
@@ -1,0 +1,36 @@
+//
+//  ErrorView.swift
+//  GatheRunner
+//
+//  Created by 김동현 on 2022/11/29.
+//
+
+import SwiftUI
+
+struct ErrorView: View {
+    private enum Size {
+        static let padding: CGFloat = 40
+    }
+    
+    private enum Label {
+        static let title = "에러 발생"
+        static let retry = "재시도"
+    }
+    
+    let errorMessage: String
+    let retryAction: () -> Void
+    
+    var body: some View {
+        VStack {
+            Text(Label.title)
+                .font(.title)
+            
+            Text(errorMessage)
+                .font(.callout)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, Size.padding).padding()
+            
+            Button(action: retryAction, label: { Text(Label.retry).bold() } )
+        }
+    }
+}

--- a/GatheRunner/Utils/FetchStatusType.swift
+++ b/GatheRunner/Utils/FetchStatusType.swift
@@ -1,0 +1,114 @@
+//
+//  FetchStatusType.swift
+//  GatheRunner
+//
+//  Created by 김동현 on 2022/11/29.
+//
+
+import Foundation
+
+struct FetchStatusType: Equatable {
+    init(status: FetchStatus, type: FetchType) {
+        self.status = status
+        self.type = type
+    }
+
+    let status: FetchStatus
+    let type: FetchType
+
+    var isInitial: Bool {
+        type == .initial
+    }
+
+    var isMore: Bool {
+        type == .more
+    }
+
+    var isRefresh: Bool {
+        type == .refresh
+    }
+
+    var isNone: Bool {
+        status == .none
+    }
+
+    var isFetching: Bool {
+        status == .fetching
+    }
+
+    var isSuccess: Bool {
+        status == .success
+    }
+
+    var isFailure: Bool {
+        if case .failure = status {
+            return true
+        } else {
+            return false
+        }
+    }
+
+    var isLoadMore: Bool {
+        isMore && isFetching
+    }
+
+    static func none(_ type: FetchType) -> Self {
+        .init(status: .none, type: type)
+    }
+
+    static func fetching(_ type: FetchType) -> Self {
+        .init(status: .fetching, type: type)
+    }
+
+    static func success(_ type: FetchType) -> Self {
+        .init(status: .success, type: type)
+    }
+
+    static func failure(_ type: FetchType) -> Self {
+        .init(status: .failure, type: type)
+    }
+}
+
+enum FetchType {
+    case initial
+    case more
+    case refresh
+}
+
+enum FetchStatus: Equatable {
+    case none
+    case fetching
+    case success
+    case failure
+
+    var isFailed: Bool {
+        switch self {
+        case .failure: return true
+        default: return false
+        }
+    }
+
+    static func == (lhs: FetchStatus, rhs: FetchStatus) -> Bool {
+        switch (lhs, rhs) {
+        case (.none, .none),
+            (.fetching, .fetching),
+            (.success, .success),
+            (.failure, .failure):
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func === (lhs: FetchStatus, rhs: FetchStatus) -> Bool {
+        switch (lhs, rhs) {
+        case (.none, .none),
+            (.fetching, .fetching),
+            (.success, .success),
+            (.failure, .failure):
+            return true
+        default:
+            return false
+        }
+    }
+}


### PR DESCRIPTION
# 주요 변경사항
	- 로딩화면 및 에러화면 로직 추가(LoadableView, FetchStatusType, ActivityIndicatorView, ErrorView)
	- FetchStatus 로직을 통해 AuthSettingView 관련 버그 수정(회원탈퇴 후에도 화면이 종료되지 않았던 문제) 
	- Authentication View 및 ViewModel에 FetchStatus 적용 및 리팩토링

# 추가 작업 예정사항
	- FetchStatus 로직 NetworkLayer에 적용(2차) (뷰모델에서 분리)
	- Network Error(2차) 구현 후 ViewModel의 에러메시지 핸들링 작업


